### PR TITLE
Login users after registration.

### DIFF
--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -47,8 +47,9 @@ module DeviseTokenAuth
               client_config: params[:config_name],
               redirect_url: @redirect_url
             })
+          end
 
-          else
+          if @resource.confirmed? || (@resource.respond_to?(:active_for_authentication?) && @resource.active_for_authentication?)
             # email auth has been bypassed, authenticate user
             @client_id = SecureRandom.urlsafe_base64(nil, false)
             @token     = SecureRandom.urlsafe_base64(nil, false)


### PR DESCRIPTION
This relies on a setting in devise.rb in the carol api repo. `allow_unconfirmed_access_for` makes `active_for_authentication` available but the library wasn't taking it into account. @wesley-harding 